### PR TITLE
Fix: Register 'laravel-trash-cleaner' service to resolve facade class error

### DIFF
--- a/src/LaravelTrashCleanerServiceProvider.php
+++ b/src/LaravelTrashCleanerServiceProvider.php
@@ -37,11 +37,9 @@ class LaravelTrashCleanerServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'laravel-trash-cleaner');
 
-      /*
         $this->app->singleton('laravel-trash-cleaner', function () {
             return new LaravelTrashCleaner;
         });
-      */
     }
 
     /**


### PR DESCRIPTION
## Description

This PR uncommented the service registration for the `laravel-trash-cleaner` service in `LaravelTrashCleanerServiceProvider`.

### Changes:
- Uncommented the line to register the `laravel-trash-cleaner` service using `$this->app->singleton()`.

### Reason:
The service was not being registered in the service container, causing the "Target class does not exist" error when using the facade. This change ensures the facade works correctly by binding the service to the container.


![WindowsTerminal_dHnFZrtNLl](https://github.com/user-attachments/assets/f38ad185-d0dc-4b2b-806f-885f9bb67872)
